### PR TITLE
feat: 添加简单 CC License 组件，以便复用

### DIFF
--- a/.vitepress/theme/components/CCBYSA.vue
+++ b/.vitepress/theme/components/CCBYSA.vue
@@ -1,0 +1,52 @@
+<template>
+  <div class="cc-license-container">
+    <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="license noopener noreferrer">
+      <img src="https://licensebuttons.net/l/by-sa/4.0/88x31.png" alt="CC BY-SA" />
+    </a>
+    <p>
+      本作品采用
+      <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="license noopener noreferrer">
+        CC BY-SA 4.0 许可协议
+      </a>
+      发布。
+    </p>
+  </div>
+</template>
+
+<style scoped>
+  .cc-license-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1em;
+    max-width: 600px;
+    margin: 2em auto;
+    padding: 0 1em;
+    flex-wrap: wrap;
+  }
+
+  .cc-license-container img {
+    flex-shrink: 0;
+    height: 31px;
+    align-items: center;
+  }
+
+  .cc-license-container p {
+    margin: 0;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  @media (max-width: 600px) {
+    .cc-license-container {
+      flex-direction: column;
+      align-items: center;
+    }
+
+    .cc-license-container img {
+      margin-bottom: 0.5em;
+      align-items: center;
+    }
+  }
+</style>
+

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -5,6 +5,7 @@ import DefaultTheme from 'vitepress/theme'
 import './style.css'
 
 import PostList from './components/PostList.vue'
+import CCBYSA from './components/CCBYSA.vue'
 
 export default {
   extends: DefaultTheme,
@@ -15,5 +16,6 @@ export default {
   },
   enhanceApp({ app, router, siteData }) {
     app.component('PostList', PostList)
+    app.component('CCBYSA', CCBYSA)
   }
 } satisfies Theme

--- a/about/THE_WHULUG_WAY.md
+++ b/about/THE_WHULUG_WAY.md
@@ -92,5 +92,4 @@
 
 ---
 
-本文档采用 Creative Commons Attribution-ShareAlike 4.0 International License (CC BY-SA 4.0) 许可协议发布。
-如需查看完整许可证文本，请访问：[https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/) 或查阅本仓库根目录下的 LICENSE 文件。
+<CCBYSA/>


### PR DESCRIPTION
或许接下来还可以
- 根据 frontmatter 自动添加 License 信息。至少目前这种添加方式对写作者不是很友好。
- 改好看点

效果如图：
<img width="1215" height="780" alt="image" src="https://github.com/user-attachments/assets/0bf22501-52c5-4735-b08b-fa1db60dccf5" />
